### PR TITLE
[V1] Cleanup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,9 +21,7 @@ module.exports = {
         'no-console': [
             'warn'
         ],
-        'no-unused-vars': [
-            'warn'
-        ],
+        '@typescript-eslint/no-unused-vars': ['warn'],
         'eol-last': [
             'error',
             'always'

--- a/src/images.d.ts
+++ b/src/images.d.ts
@@ -1,1 +1,0 @@
-declare module '*.png';

--- a/src/v1/components/canvas-proxy/background-layer.tsx
+++ b/src/v1/components/canvas-proxy/background-layer.tsx
@@ -3,22 +3,16 @@ import { styled } from 'styled-components';
 
 const Background = styled.div`
     position: absolute;
-    top: 0;
-    left: 0;
+    inset: 0;
     z-index: -1;
 `;
 
-interface BackgroundLayerProps {
-    width : number,
-    height : number
-}
-
-export function BackgroundLayer({width, height} : BackgroundLayerProps) {
+export function BackgroundLayer() {
     const patternId = useId();
 
     return (
-        <Background style={{width: width, height: height}}>
-            <svg width={width} height={height} xmlns="http://www.w3.org/2000/svg">
+        <Background>
+            <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
                 <defs>
                     <pattern id={patternId} x="0" y="0" width="2" height="2" patternUnits="userSpaceOnUse">
                         <rect x="0" y="0" width="1" height="1" fill="rgba(138, 138, 138, 1)" />
@@ -26,8 +20,8 @@ export function BackgroundLayer({width, height} : BackgroundLayerProps) {
                     </pattern>
                 </defs>
 
-                <rect fill="rgba(199, 199, 199, 1)" width={width} height={height} />
-                <rect fill={`url(#${patternId})`} width={width} height={height} />
+                <rect fill="rgba(199, 199, 199, 1)" width="100%" height="100%" />
+                <rect fill={`url(#${patternId})`} width="100%" height="100%" />
             </svg>
         </Background>
     );

--- a/src/v1/components/canvas-proxy/canvas-proxy.tsx
+++ b/src/v1/components/canvas-proxy/canvas-proxy.tsx
@@ -31,8 +31,6 @@ export interface CanvasProxyProps {
     canvas: HTMLCanvasElement,
     zoomFactor : number,
     color : Color,
-    width: number,
-    height : number,
     draw : (x : number, y : number, color : string) => void,
     erase : (x : number, y : number) => void,
     pick : (x : number, y : number, canvas : HTMLCanvasElement) => void,
@@ -40,7 +38,7 @@ export interface CanvasProxyProps {
     tool : toolType
 }
 
-export function CanvasProxy({ canvas, zoomFactor, color, width, height, draw, erase, pick, addToColorHistory, tool }: CanvasProxyProps) {
+export function CanvasProxy({ canvas, zoomFactor, color, draw, erase, pick, addToColorHistory, tool }: CanvasProxyProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const markerRef = useRef<HTMLSpanElement>(null);
 
@@ -110,9 +108,9 @@ export function CanvasProxy({ canvas, zoomFactor, color, width, height, draw, er
             onPointerMove={handlePointerMove}
             onPointerLeave={handlePointerLeave}
             onPointerDown={handlePointerDown}
-            style={{transform: `scale(${zoomFactor})`, width: width, height: height}}
+            style={{transform: `scale(${zoomFactor})`}}
         >
-            <BackgroundLayer width={width} height={height}/>
+            <BackgroundLayer/>
             <Marker ref={markerRef}/>
         </Container>
     );

--- a/src/v1/components/canvas-proxy/install.tsx
+++ b/src/v1/components/canvas-proxy/install.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { CanvasProxy as InternalCanvas } from './canvas-proxy';
+import { CanvasProxy as InternalCanvasProxy } from './canvas-proxy';
 import { useSnapshot } from 'valtio';
 import { ZoomState } from '../zoom/state';
 import { ToolState } from '../tool/state';
-import { CanvasState } from '../canvas/state';
 import { ColorState } from '../color/state';
 import Color from 'colorjs.io';
 
@@ -14,22 +13,18 @@ export function installCanvasProxy(
     pick : (x : number, y : number, canvas : HTMLCanvasElement) => void,
     addToColorHistory : (newColor : Color) => void,
     toolState : ToolState,
-    canvasState : CanvasState,
     colorState : ColorState,
     canvas : HTMLCanvasElement
 ) {
     const CanvasProxy = () => {
-        const canvasSnapshot = useSnapshot(canvasState);
         const zoomSnapshot = useSnapshot(zoomState);
         const toolSnapshot = useSnapshot(toolState);
         const colorSnapshot = useSnapshot(colorState);
 
-        return <InternalCanvas 
+        return <InternalCanvasProxy
             canvas={canvas}
             zoomFactor={zoomSnapshot.zoomFactor}
             color={colorSnapshot.color}
-            width={canvasSnapshot.width}
-            height={canvasSnapshot.height}
             draw={draw}
             erase={erase}
             pick={pick}

--- a/src/v1/components/canvas/install.tsx
+++ b/src/v1/components/canvas/install.tsx
@@ -9,6 +9,7 @@ export function installCanvas() {
     canvas.width = state.width;
     canvas.height = state.height;
     canvas.style.imageRendering = 'pixelated';
+    canvas.style.display = 'block';
 
     const resize = (newWidth : number, newHeight : number) => presenter.resize(state, canvas, newWidth, newHeight);
 

--- a/src/v1/components/color-picker/color-picker.tsx
+++ b/src/v1/components/color-picker/color-picker.tsx
@@ -90,7 +90,7 @@ export function ColorPicker({ color, onChange } : ColorPickerProps) {
         colorCtx.fillRect(0, 0, colorCtx.canvas.width, colorCtx.canvas.height);
     }, [color]);
 
-    // Handle pointer in hue slider
+    // Handle pointer
     useEffect(() => {
         if ((!isColorDown && !isHueDown) || !colorCanvasRef.current || !hueCanvasRef.current) {
             return;

--- a/src/v1/components/color/state.ts
+++ b/src/v1/components/color/state.ts
@@ -1,7 +1,5 @@
 import Color from 'colorjs.io';
-import { proxy, ref } from 'valtio';
-
-type Ref<T extends object> = ReturnType<typeof ref<T>>;
+import { proxy, ref, Ref } from 'valtio';
 
 export class ColorState {
     color : Ref<Color> = ref(new Color('hsv', [0, 0, 100]));

--- a/src/v1/components/display/display.tsx
+++ b/src/v1/components/display/display.tsx
@@ -6,22 +6,18 @@ const Wrapper = styled.div`
     height: 100%;
     width: 100%;
     overflow: hidden;
-    transform-origin: center;
     position: relative;
 `;
 
 export interface DisplayProps {
-    zoomFactor : number,
     onWheel : (e : React.WheelEvent) => void,
     Canvas : React.ComponentType
 }
 
-export function Display({onWheel: onWheel, Canvas} : DisplayProps) {
-
+export function Display({ onWheel: onWheel, Canvas } : DisplayProps) {
     return (
         <Wrapper onWheel={onWheel}>
             <Canvas/>
         </Wrapper>
     );
-
 }

--- a/src/v1/components/display/install.tsx
+++ b/src/v1/components/display/install.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
-import { useSnapshot } from 'valtio';
-import { ZoomState } from '../zoom/state';
 import { Display as InternalDisplay } from './display';
+import { clamp } from '../../utils/math';
 
 export function installDisplay(
-    zoomState : ZoomState, 
-    updateZoomFactor : (newZoomFactor : number) => void, 
+    zoom : (scale : number) => void, 
     Canvas : React.ComponentType
 ) {
     const Display = () => {
-        const snapshot = useSnapshot(zoomState);
-        
         function onWheel(e : React.WheelEvent) {
-            const scrollDistance = e.deltaY < 0 ? zoomState.scrollSpeed : -zoomState.scrollSpeed;
-            const newZoomFactor = zoomState.zoomFactor + scrollDistance > 0.1 ? zoomState.zoomFactor + scrollDistance : 0.1;
-            updateZoomFactor(newZoomFactor);
+            zoom(clamp(-e.deltaY, -1, 1));
         }
 
         return <InternalDisplay
-            zoomFactor={snapshot.zoomFactor}
             onWheel={onWheel}
             Canvas={Canvas}
         />;

--- a/src/v1/components/eye-dropper/install.tsx
+++ b/src/v1/components/eye-dropper/install.tsx
@@ -26,6 +26,6 @@ export function installEyeDropper(
 
     return {
         pick,
-        ColorPickerButton: EyeDropperButton
+        EyeDropperButton
     };
 }

--- a/src/v1/components/skeleton/skeleton.tsx
+++ b/src/v1/components/skeleton/skeleton.tsx
@@ -74,7 +74,7 @@ type SkeletonProps = {
     ColorPicker : React.ComponentType,
     EraserButton : React.ComponentType,
     PaintbrushButton : React.ComponentType,
-    ColorPickerButton : React.ComponentType,
+    EyeDropperButton : React.ComponentType,
     ColorHistory : React.ComponentType
 };
 
@@ -86,7 +86,7 @@ export function Skeleton({
     ColorPicker,
     EraserButton,
     PaintbrushButton,
-    ColorPickerButton,
+    EyeDropperButton,
     ColorHistory
 }: SkeletonProps) {
 
@@ -96,7 +96,7 @@ export function Skeleton({
                 <ToolBar>
                     <PaintbrushButton/>
                     <EraserButton/>
-                    <ColorPickerButton/>
+                    <EyeDropperButton/>
                 </ToolBar>
                 <ColorPanel>
                     <ColorPicker/>

--- a/src/v1/components/zoom/install.tsx
+++ b/src/v1/components/zoom/install.tsx
@@ -5,10 +5,10 @@ export function installZoom() {
     const state = createZoomState();
     const presenter = new ZoomPresenter();
 
-    const updateZoomFactor = (newZoomFactor : number) => presenter.updateZoomFactor(state, newZoomFactor);
+    const zoom = (scale : number) => presenter.zoom(state, scale);
 
     return {
-        updateZoomFactor,
+        zoom,
         state
     };
 }

--- a/src/v1/components/zoom/presenter.ts
+++ b/src/v1/components/zoom/presenter.ts
@@ -1,10 +1,12 @@
-import {ZoomState} from './state';
+import { ZoomState } from './state';
+
+const MIN_ZOOM_FACTOR = 0.1;
 
 export class ZoomPresenter {
     constructor() {
     }
 
-    updateZoomFactor(state : ZoomState, newZoomFactor : number) {
-        state.zoomFactor = newZoomFactor;
+    zoom(state : ZoomState, scale : number) {
+        state.zoomFactor = Math.max(MIN_ZOOM_FACTOR, state.zoomFactor + (state.scrollSpeed * scale));
     }
 }

--- a/src/v1/install.tsx
+++ b/src/v1/install.tsx
@@ -1,22 +1,22 @@
 import React from 'react';
 import { Skeleton } from './components/skeleton/skeleton';
 import { installDisplay } from './components/display/install';
-import { installCanvasProxy } from './components/canvas-proxy/install.tsx';
+import { installCanvasProxy } from './components/canvas-proxy/install';
 import { installZoom } from './components/zoom/install';
-import { installExport } from './components/export/install.tsx';
-import { installClearCanvas } from './components/clear-canvas/install.tsx';
+import { installExport } from './components/export/install';
+import { installClearCanvas } from './components/clear-canvas/install';
 import { installPaintBrush } from './components/paint-brush/install';
-import { installEraser } from './components/eraser/install.tsx';
-import { installTool } from './components/tool/install.ts';
-import { installEyeDropper } from './components/eye-dropper/install.tsx';
-import { installCanvas } from './components/canvas/install.tsx';
-import { installColorPicker } from './components/color-picker/install.tsx';
-import { installColor } from './components/color/install.tsx';
-import { installColorHistory } from './components/color-history/install.tsx';
-import { installResize } from './components/resize/install.tsx';
+import { installEraser } from './components/eraser/install';
+import { installTool } from './components/tool/install';
+import { installEyeDropper } from './components/eye-dropper/install';
+import { installCanvas } from './components/canvas/install';
+import { installColorPicker } from './components/color-picker/install';
+import { installColor } from './components/color/install';
+import { installColorHistory } from './components/color-history/install';
+import { installResize } from './components/resize/install';
 
 export function installApp() {
-    const { state : zoomState, updateZoomFactor } = installZoom();
+    const { state : zoomState, zoom } = installZoom();
     const { state : toolState, changeTool } = installTool();
     const { state : colorState, updateColor, addToColorHistory } = installColor();
     const { state : canvasState, canvas, resize } = installCanvas();
@@ -24,9 +24,9 @@ export function installApp() {
     const { ColorHistory } = installColorHistory(colorState, updateColor);
     const { draw, PaintbrushButton } = installPaintBrush(toolState, changeTool, canvas);
     const { erase, EraserButton } = installEraser(toolState, changeTool, canvas);
-    const { pick, ColorPickerButton } = installEyeDropper(toolState, changeTool, updateColor);
-    const { CanvasProxy } = installCanvasProxy(zoomState, draw, erase, pick, addToColorHistory, toolState, canvasState, colorState, canvas);
-    const { Display } = installDisplay(zoomState, updateZoomFactor, CanvasProxy);
+    const { pick, EyeDropperButton } = installEyeDropper(toolState, changeTool, updateColor);
+    const { CanvasProxy } = installCanvasProxy(zoomState, draw, erase, pick, addToColorHistory, toolState, colorState, canvas);
+    const { Display } = installDisplay(zoom, CanvasProxy);
     const { ExportButton } = installExport(canvas);
     const { ClearCanvasButton } = installClearCanvas(canvas);
     const { ResizeButton } = installResize(canvasState, resize);
@@ -40,7 +40,7 @@ export function installApp() {
             ColorPicker={ColorPicker}
             EraserButton={EraserButton}
             PaintbrushButton={PaintbrushButton}
-            ColorPickerButton={ColorPickerButton}
+            EyeDropperButton={EyeDropperButton}
             ColorHistory={ColorHistory}
         />
     );

--- a/src/v1/types/image.d.ts
+++ b/src/v1/types/image.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+    const path: string;
+    export default path;
+}

--- a/src/v1/types/valtio.d.ts
+++ b/src/v1/types/valtio.d.ts
@@ -1,0 +1,5 @@
+import { ref } from 'valtio';
+
+declare module 'valtio' {
+    type Ref<T extends object> = ReturnType<typeof ref<T>>
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "jsx": "react",                                      /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    "typeRoots": ["./src/v1/types"],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
Changes in this PR:

- Removed `CanvasState` dependency from `canvas-proxy` feature
- Removed `ZoomState` dependency from `display` feature
- Code to update zoom factor now lives within `ZoomPresenter`. Renamed `updateZoomFactor` to `zoom`
- Moved type declarations into their own `types` folder which is now referenced in the new `tsconfig.json` (see the `typeRoots` field). Adding the `types` folder to `typeRoots` allows the TS language server to pick up the types so that they're available to all of our code.